### PR TITLE
hammerhead: properly symlink WCD9320 codec drivers

### DIFF
--- a/hammerhead/lge/hammerhead/device-vendor.mk
+++ b/hammerhead/lge/hammerhead/device-vendor.mk
@@ -16,7 +16,8 @@ PRODUCT_PACKAGES += \
     qcrilmsgtunnel \
     TimeService \
     shutdownlistener \
-    UpdateSetting
+    UpdateSetting \
+    libacdbloader
 
 LOCAL_STEM := hammerhead/device-partial.mk
 

--- a/hammerhead/qcom/hammerhead/proprietary/Android.mk
+++ b/hammerhead/qcom/hammerhead/proprietary/Android.mk
@@ -34,6 +34,6 @@ LOCAL_POST_INSTALL_CMD := \
         ln -sf /data/misc/audio/mbhc.bin \
         $(TARGET_OUT_ETC)/firmware/wcd9320/wcd9320_mbhc.bin
 
-#include $(BUILD_PREBUILT)
+include $(BUILD_PREBUILT)
 
 endif


### PR DESCRIPTION
Needed for kernel ALSA drivers
